### PR TITLE
Update Jira provider address in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "mobilesolutionworks.com/development-platform/atlassian-cloud",
+		Address: "github.com/yunarta/atlassian-cloud",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
Changed the address in the Jira provider from "mobilesolutionworks.com/development-platform/atlassian-cloud" to "github.com/yunarta/atlassian-cloud". This update aims to refer to the correct location for the Jira provider.