### PR TITLE
Update group permissions and roles in Jira provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/yunarta/golang-quality-of-life-pack v1.0.0
 	github.com/yunarta/terraform-api-transport v1.0.0
-	github.com/yunarta/terraform-atlassian-api-client v1.3.0
+	github.com/yunarta/terraform-atlassian-api-client v1.3.11
 	github.com/yunarta/terraform-provider-commons v1.0.0
 )
 

--- a/provider/confluence_space_permission.go
+++ b/provider/confluence_space_permission.go
@@ -134,7 +134,7 @@ func UpdateSpaceRoleAssignments(ctx context.Context, receiver SpaceRoleResource,
 			return updateService.UpdateUserPermissions(user, requestedRoles)
 		},
 		func(group string, requestedRoles []string) error {
-			return updateService.UpdateUserPermissions(group, requestedRoles)
+			return updateService.UpdateGroupPermissions(group, requestedRoles)
 		},
 	)
 }
@@ -173,6 +173,6 @@ func DeleteSpaceRoleAssignments(ctx context.Context, receiver SpaceRoleResource,
 			return updateService.UpdateUserPermissions(user, requestedRoles)
 		},
 		func(group string, requestedRoles []string) error {
-			return updateService.UpdateUserPermissions(group, requestedRoles)
+			return updateService.UpdateGroupPermissions(group, requestedRoles)
 		})
 }

--- a/provider/jira_project_permission.go
+++ b/provider/jira_project_permission.go
@@ -136,7 +136,7 @@ func UpdateProjectRoleAssignments(ctx context.Context, receiver ProjectRoleResou
 			return updateService.UpdateUserRoles(user, requestedRoles)
 		},
 		func(group string, requestedRoles []string) error {
-			return updateService.UpdateUserRoles(group, requestedRoles)
+			return updateService.UpdateGroupRoles(group, requestedRoles)
 		},
 	)
 }
@@ -175,6 +175,6 @@ func DeleteProjectRoleAssignments(ctx context.Context, receiver ProjectRoleResou
 			return updateService.UpdateUserRoles(user, requestedRoles)
 		},
 		func(group string, requestedRoles []string) error {
-			return updateService.UpdateUserRoles(group, requestedRoles)
+			return updateService.UpdateGroupRoles(group, requestedRoles)
 		})
 }


### PR DESCRIPTION
The methods used for updating user permissions and roles were mistakenly used for groups in "confluence_space_permission.go" and "jira_project_permission.go". This commit corrects these calls by using the proper methods for groups. Also, the version of the "terraform-atlassian-api-client" dependency in "go.mod" has been updated.